### PR TITLE
Bug and QOL Fixes for the Lab 2 Tester

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -18,13 +18,13 @@ COURSE_DIR = "/clear/courses/comp412/students"
 
 ILOC_DIRS = []
 ILOC_DIRS = [COURSE_DIR+"/ILOC/blocks/lab" + str(n) for n in ([2])]
-ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2012/lab3"]
-ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2013/lab2"]
-ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2013/lab3"]
-ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2014/lab2"]
-ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2014/lab3"]
-ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2015/lab2"]
-ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2015/lab3"]
+# ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2012/lab3"]
+# ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2013/lab2"]
+# ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2013/lab3"]
+# ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2014/lab2"]
+# ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2014/lab3"]
+# ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2015/lab2"]
+# ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2015/lab3"]
 #Add your own directory to ILOC_DIRS list!
 
 """
@@ -80,13 +80,22 @@ def runLab3Impl(pathToImpl, pathToILOC):
     return output
 
 def run_sim(sim, pathToILOC, sim_input=None, reg_count=1000000, interlock_mode="3"):
-    cmd = [
-        sim,
-        "-s", interlock_mode,
-        "-r", str(reg_count),
-        sim_input or '',
-        pathToILOC
-    ]
+    if sim_input is None:
+        cmd = [
+            sim,
+            "-s", interlock_mode,
+            "-r", str(reg_count),
+            pathToILOC
+        ]
+    else:
+        cmd = [
+            sim,
+            "-s", interlock_mode,
+            "-r", str(reg_count),
+            '-i',
+            sim_input,
+            pathToILOC
+        ]
     process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
     stdout, stderr = process.communicate()
     
@@ -183,7 +192,7 @@ def parseSimInput(filePath):
 def execute_test_lab23(lab, reg, filePath, return_list):
     if (lab == "lab2"):
         sim = "/clear/courses/comp412/students/lab2/sim" #Path to ILOC simulator
-        ref = "~comp412/students/lab2/lab2_ref"
+        ref = "/clear/courses/comp412/students/lab2/lab2_ref"
         impl = "./412alloc"
         interlock_mode = "3"
         run = lambda impl, reg, f: runLab2Impl(impl, reg, f)
@@ -301,7 +310,11 @@ def runTests(impl, lab, reg=1000000):
         print(f'\n🙃 You passed {num_tests - fail_count}/{num_tests} tests.')
     else:
         print(f'\n🚀 You passed all {num_tests} tests!\n')
-
+    
+    # Remove the out_impl.i and/or the out_ref.i files, if present. Useful for lab2
+    for filename in ['out_impl.i', 'out_ref.i']:
+        if os.path.exists(filename):
+            os.remove(filename)
 
 def main(lab, filename):
     IMPL = filename

--- a/runner.py
+++ b/runner.py
@@ -18,13 +18,13 @@ COURSE_DIR = "/clear/courses/comp412/students"
 
 ILOC_DIRS = []
 ILOC_DIRS = [COURSE_DIR+"/ILOC/blocks/lab" + str(n) for n in ([2])]
-# ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2012/lab3"]
-# ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2013/lab2"]
-# ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2013/lab3"]
-# ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2014/lab2"]
-# ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2014/lab3"]
-# ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2015/lab2"]
-# ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2015/lab3"]
+ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2012/lab3"]
+ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2013/lab2"]
+ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2013/lab3"]
+ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2014/lab2"]
+ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2014/lab3"]
+ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2015/lab2"]
+ILOC_DIRS += [COURSE_DIR+"/ILOC/contributed/2015/lab3"]
 #Add your own directory to ILOC_DIRS list!
 
 """
@@ -80,6 +80,7 @@ def runLab3Impl(pathToImpl, pathToILOC):
     return output
 
 def run_sim(sim, pathToILOC, sim_input=None, reg_count=1000000, interlock_mode="3"):
+    # Adjust the command for the simulator depending on if there is an input or not.
     if sim_input is None:
         cmd = [
             sim,

--- a/test
+++ b/test
@@ -1,2 +1,2 @@
 #!/bin/bash 
-python ./zill412/runner.py $@
+/bin/python3.11 ./zill412/runner.py $@


### PR DESCRIPTION
Added in some quick bug fixes for the Lab 2 testing process. I'm not sure if others were encountering these bugs, but these changes fixed the tests on my end.

- Adjusted the cmd in run_sim depending on if there is an input or not. Previously, this would fail to execute if sim_input is None.
- Deleted the 'out_impl.i', 'out_ref.i' files at the end of the testing process for lab 2. Previously, they would stay after executing the tests.
- Changed the python interpreter in test to '/bin/python3.11' on CLEAR, a much faster version.

Thank you so much for making this testing suite! These have been a lifesaver for me and many other COMP 412 students :)